### PR TITLE
fs.existsSync instead of File.exists

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ class TailwindExtract {
         this.outputPath = outputPath;
 
         assert(
-            File.exists(tailwindConfigPath),
+            fs.existsSync(tailwindConfigPath),
             'Could not resolve Tailwind CSS config.'
         );
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "fs": "^0.0.1-security"
   },
   "peerDependencies": {
-    "laravel-mix": "^5.0.1",
+    "laravel-mix": "^6.0.0",
     "tailwindcss": "^1.1.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,6 +38,6 @@
   },
   "peerDependencies": {
     "laravel-mix": "^6.0.0",
-    "tailwindcss": "^2.0.4"
+    "tailwindcss": "^2.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,6 +38,6 @@
   },
   "peerDependencies": {
     "laravel-mix": "^6.0.0",
-    "tailwindcss": "^1.1.4"
+    "tailwindcss": "^2.0.4"
   }
 }


### PR DESCRIPTION
I'm reading this code and I wonder howit worked before 🤔  but now that I upgraded Laravel Mix and PostCSS in my dependencies, there's a node error on "File.exists" and says "File is not defined". Might be a trailing global accessible in previous versions of node? Or something that webpack passed before but doesn't anymore?